### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
     ports:
       - '9944:9944'
       - '9933:9933'
-    command: --dev --base-path /substrate/db --ws-external --rpc-cors=all --rpc-external --rpc-methods=Unsafe --no-telemetry --no-prometheus --pruning=archive
+    command: --dev --base-path /substrate/db  --rpc-cors=all --rpc-external --rpc-methods=Unsafe --no-telemetry --no-prometheus --pruning=archive
 
   mysql:
     image: mysql:latest


### PR DESCRIPTION
The latest command is updated, old commands will not start： Need to delete the --ws-external parameter
This is the explanation of substrate

https://github.com/paritytech/substrate/pull/13384